### PR TITLE
change window onresize to canvas resizeobserver

### DIFF
--- a/game.js
+++ b/game.js
@@ -1086,4 +1086,4 @@ window.onload = function () {
   Game.run();
 };
 
-window.addEventListener("resize", resizeCanvas);
+new ResizeObserver(resizeCanvas).observe(canvas);

--- a/game.js
+++ b/game.js
@@ -1096,4 +1096,4 @@ window.onload = function () {
   Game.run();
 };
 
-new ResizeObserver(resizeCanvas).observe(canvas);
+window.addEventListener("resize", resizeCanvas);

--- a/index.html
+++ b/index.html
@@ -3541,6 +3541,7 @@
       id="main"
     >
       <!-- Start game -->
+      <!-- NEVER STYLE CANVAS.STYLE.WIDTH OR CANVAS.STYLE.HEIGHT ANYWHERE -->
       <canvas
         id="canvas"
         class="block portrait:fixed left-0"


### PR DESCRIPTION
click to move stops working sometimes when transitioning from mobile preview back to desktop on desktop browsers, investigating, but this shouldnt be a prime use case right?

Edit: seems to have been fixed in latest master